### PR TITLE
Deal with custom tag unmarshalers that output a map[string]

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -243,6 +243,17 @@ func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (in
 			}
 		}
 		return arr, nil
+	case map[string]interface{}:
+		// We need to recurse into maps for the same reasons as above
+
+		for k, v := range typedYAMLObj {
+			typedYAMLObj[k], err = convertToJSONableObject(v, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return typedYAMLObj, nil
 	default:
 		// If the target type is a string and the YAML type is a number,
 		// convert the YAML type to a string.


### PR DESCRIPTION
If some code has registered a custom YAML tag unmarshaler that outputs a data structure not dealt with in `convertToJSONableObject` then there will be a failure.

This PR allows for `map[string]interface{}` which can be output by the tag unmarshalers used in [here in AWS's goformation](https://github.com/awslabs/goformation/blob/master/intrinsics/intrinsics.go).

A better PR would refactor all of `convertToJSONableObject` to use `reflect` but that can wait for another day :)